### PR TITLE
Pair API IDs to RFIDs

### DIFF
--- a/backend/card.py
+++ b/backend/card.py
@@ -4,9 +4,9 @@ from typing import Any
 class Card:
     """A cards API ID along with the mat it was played to. CONSIDER THIS IMMUTABLE; only CardRepository should directly change its values."""
 
-    def __init__(self, rfid: int, mat_id: int, api_id: str | None = None):
-        self.rfid: int = rfid
-        self.mat_id: int = mat_id
+    def __init__(self, rfid: str, mat_id: str, api_id: str | None = None):
+        self.rfid: str = rfid
+        self.mat_id: str = mat_id
         self.api_id: str | None = api_id
         """None if the frontend hasn't provided an API ID yet"""
 

--- a/backend/card.py
+++ b/backend/card.py
@@ -4,10 +4,11 @@ from typing import Any
 class Card:
     """A cards API ID along with the mat it was played to. CONSIDER THIS IMMUTABLE; only CardRepository should directly change its values."""
 
-    def __init__(self, mat_id: int, api_id: str | None = None):
+    def __init__(self, rfid: int, mat_id: int, api_id: str | None = None):
+        self.rfid: int = rfid
         self.mat_id: int = mat_id
         self.api_id: str | None = api_id
         """None if the frontend hasn't provided an API ID yet"""
 
     def toJSON(self) -> dict[str, Any]:
-        return {"mat_id": self.mat_id, "api_id": self.api_id}
+        return {"rfid": self.rfid, "mat_id": self.mat_id, "api_id": self.api_id}

--- a/backend/endpoints/frontend_endpoints.py
+++ b/backend/endpoints/frontend_endpoints.py
@@ -9,7 +9,7 @@ def get_current_board():
 
 
 @current_app.patch("/card/<rfid>")
-def pair_api_id(rfid: int):
+def pair_api_id(rfid: str):
     data = request.json
     print(f"Patch for card RFID#{rfid}:", data)
 

--- a/backend/endpoints/frontend_endpoints.py
+++ b/backend/endpoints/frontend_endpoints.py
@@ -1,4 +1,4 @@
-from flask import current_app
+from flask import current_app, request
 
 from repository import CardRepository
 
@@ -6,3 +6,26 @@ from repository import CardRepository
 @current_app.get("/cards")
 def get_current_board():
     return {"cards": [card.toJSON() for card in CardRepository().get_all()]}
+
+
+@current_app.patch("/card/<rfid>")
+def pair_api_id(rfid: int):
+    data = request.json
+    print(f"Patch for card RFID#{rfid}:", data)
+
+    try:
+        api_id = data["api_id"]
+    except KeyError:
+        return {
+            "success": False,
+            "message": "Must provide an api_id field.",
+        }, 400
+
+    try:
+        CardRepository().set_API_ID(rfid, api_id)
+        return {"success": True, "rfid": rfid, "api_id": api_id}
+    except KeyError as e:
+        return {
+            "success": False,
+            "message": f"No card with rfid={rfid}",
+        }, 400

--- a/backend/repository.py
+++ b/backend/repository.py
@@ -28,7 +28,7 @@ class CardRepository:
             self._cards: Dict[int, Card] = {}
             """Dictionary with RFID index and Card values."""
 
-    def get_card(self, rfid: int) -> Card | None:
+    def get_card(self, rfid: str) -> Card | None:
         with self._lock:
             return self._cards.get(rfid)
 
@@ -36,12 +36,12 @@ class CardRepository:
         with self._lock:
             return [card for card in self._cards.values()]
 
-    def set_API_ID(self, rfid: int, api_id: str) -> None:
+    def set_API_ID(self, rfid: str, api_id: str) -> None:
         """Raises KeyError if no card with given rfid was found."""
         with self._lock:
             self._cards[rfid].api_id = api_id
 
-    def add_card(self, rfid: int, mat_id: int, api_id: str | None = None) -> None:
+    def add_card(self, rfid: str, mat_id: str, api_id: str | None = None) -> None:
         """Raises ValueError if given RFID already exists."""
         with self._lock:
             if rfid in self._cards:
@@ -49,7 +49,7 @@ class CardRepository:
             else:
                 self._cards[rfid] = Card(rfid, mat_id, api_id)
 
-    def remove_card(self, rfid) -> bool:
+    def remove_card(self, rfid: str) -> bool:
         """Returns True if rfid existed and was successfully deleted."""
         with self._lock:
             if rfid in self._cards:

--- a/backend/repository.py
+++ b/backend/repository.py
@@ -47,7 +47,7 @@ class CardRepository:
             if rfid in self._cards:
                 raise ValueError()
             else:
-                self._cards[rfid] = Card(mat_id, api_id)
+                self._cards[rfid] = Card(rfid, mat_id, api_id)
 
     def remove_card(self, rfid) -> bool:
         """Returns True if rfid existed and was successfully deleted."""

--- a/frontend/src/app/admin-page/admin-page.component.html
+++ b/frontend/src/app/admin-page/admin-page.component.html
@@ -1,5 +1,6 @@
 <div>
   <h2>This is the admin page</h2>
+  <display-cards [showUnpairedCards]="true" />
   <card-search />
   <div><button routerLink="/">Go back to the main page</button></div>
 </div>

--- a/frontend/src/app/admin-page/admin-page.component.html
+++ b/frontend/src/app/admin-page/admin-page.component.html
@@ -1,6 +1,5 @@
 <div>
   <h2>This is the admin page</h2>
   <display-cards [showUnpairedCards]="true" />
-  <card-search />
   <div><button routerLink="/">Go back to the main page</button></div>
 </div>

--- a/frontend/src/app/admin-page/card-search/card-search.component.html
+++ b/frontend/src/app/admin-page/card-search/card-search.component.html
@@ -1,11 +1,13 @@
 <div>
+  <h2>Choose card to pair with RFID {{ rfid }}</h2>
+
   <div>
     <input type="text" placeholder="Card Name" #title />
     <button (click)="searchByTitle(title.value.trim())">Search</button>
   </div>
 
   <div *ngFor="let card of cards">
-    <h5>{{ card["name"] }}</h5>
+    <h5>{{ card["name"] }} <button (click)="pairAPIId(card)">Pair</button></h5>
     <div *ngIf="getCardImage(card) !== null; else no_image">
       <img [src]="getCardImage(card)" />
     </div>

--- a/frontend/src/app/admin-page/card-search/card-search.component.ts
+++ b/frontend/src/app/admin-page/card-search/card-search.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import { CardAPIService } from 'src/app/services/card-api.service';
 import { GameStateService } from 'src/app/services/game-state.service';
@@ -18,7 +18,8 @@ export class CardSearchComponent implements OnInit {
   constructor(
     private readonly cardAPI: CardAPIService,
     private readonly gameStateService: GameStateService,
-    private readonly route: ActivatedRoute
+    private readonly route: ActivatedRoute,
+    private readonly router: Router
   ) {}
 
   public ngOnInit(): void {
@@ -59,7 +60,10 @@ export class CardSearchComponent implements OnInit {
     }
 
     this.gameStateService.pairAPIId(this.rfid, card['id']).subscribe(
-      (resp) => console.log('Successfully updated API ID!'),
+      (resp) => {
+        console.log('Successfully updated API ID!');
+        this.router.navigate(['/admin']);
+      },
       (err) =>
         console.error(`Error updating API ID for card RFID=${this.rfid}`, err)
     );

--- a/frontend/src/app/admin-page/card-search/card-search.component.ts
+++ b/frontend/src/app/admin-page/card-search/card-search.component.ts
@@ -1,17 +1,29 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 
 import { CardAPIService } from 'src/app/services/card-api.service';
+import { GameStateService } from 'src/app/services/game-state.service';
 
 @Component({
   selector: 'card-search',
   templateUrl: './card-search.component.html',
   styleUrls: ['./card-search.component.scss'],
 })
-export class CardSearchComponent {
+export class CardSearchComponent implements OnInit {
   public results: any = undefined;
   public cards: any = [];
+  /** The RFID that the chosen card will be associated with. */
+  public rfid: string | null = null;
 
-  constructor(private readonly cardAPI: CardAPIService) {}
+  constructor(
+    private readonly cardAPI: CardAPIService,
+    private readonly gameStateService: GameStateService,
+    private readonly route: ActivatedRoute
+  ) {}
+
+  public ngOnInit(): void {
+    this.rfid = this.route.snapshot.paramMap.get('rfid');
+  }
 
   public searchByTitle(cardTitle: string) {
     this.cardAPI.searchByTitle(cardTitle).subscribe(
@@ -36,5 +48,20 @@ export class CardSearchComponent {
       // Card response doesn't follow normal format
     }
     return null;
+  }
+
+  public pairAPIId(card: any) {
+    if (this.rfid === null) {
+      console.error('Error: Can not pair without an RFID (rfid is null)');
+      return;
+    } else if (card['id'] === undefined) {
+      console.error("Error: Can't find card's ID.");
+    }
+
+    this.gameStateService.pairAPIId(this.rfid, card['id']).subscribe(
+      (resp) => console.log('Successfully updated API ID!'),
+      (err) =>
+        console.error(`Error updating API ID for card RFID=${this.rfid}`, err)
+    );
   }
 }

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -3,11 +3,21 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { MainPageComponent } from './main-page/main-page.component';
 import { AdminPageComponent } from './admin-page/admin-page.component';
+import { CardSearchComponent } from './admin-page/card-search/card-search.component';
 
 const routes: Routes = [
   {
     path: 'admin',
-    component: AdminPageComponent,
+    children: [
+      {
+        path: '',
+        component: AdminPageComponent,
+      },
+      {
+        path: 'pair/:rfid',
+        component: CardSearchComponent,
+      },
+    ],
   },
   {
     // The default route

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { AdminPageComponent } from './admin-page/admin-page.component';
 import { TalkToBackendComponent } from './talk-to-backend/talk-to-backend.component';
 import { CardSearchComponent } from './admin-page/card-search/card-search.component';
 import { DisplayCardsComponent } from './shared/display-cards/display-cards.component';
+import { CardComponent } from './shared/display-cards/card/card.component';
 
 @NgModule({
   declarations: [
@@ -25,6 +26,7 @@ import { DisplayCardsComponent } from './shared/display-cards/display-cards.comp
     AdminPageComponent,
     CardSearchComponent,
     DisplayCardsComponent,
+    CardComponent,
   ],
   imports: [BrowserModule, AppRoutingModule, CommonModule, HttpClientModule],
   providers: [],

--- a/frontend/src/app/models/card.ts
+++ b/frontend/src/app/models/card.ts
@@ -1,4 +1,5 @@
 export interface Card {
+  rfid: number;
   mat_id: number;
   api_id: string | null;
 }

--- a/frontend/src/app/models/card.ts
+++ b/frontend/src/app/models/card.ts
@@ -1,5 +1,5 @@
 export interface Card {
-  rfid: number;
-  mat_id: number;
+  rfid: string;
+  mat_id: string;
   api_id: string | null;
 }

--- a/frontend/src/app/services/game-state.service.ts
+++ b/frontend/src/app/services/game-state.service.ts
@@ -17,4 +17,15 @@ export class GameStateService {
       .get<{ cards: Card[] }>(BACKEND_URL + '/cards')
       .pipe(map((msg: { cards: Card[] }) => msg.cards));
   }
+
+  public pairAPIId(
+    rfid: number,
+    api_id: string
+  ): Observable<{ success: string }> {
+    const body = { api_id };
+    return this.http.patch<{ success: string }>(
+      BACKEND_URL + `/card/${rfid}`,
+      body
+    );
+  }
 }

--- a/frontend/src/app/services/game-state.service.ts
+++ b/frontend/src/app/services/game-state.service.ts
@@ -19,7 +19,7 @@ export class GameStateService {
   }
 
   public pairAPIId(
-    rfid: number,
+    rfid: string,
     api_id: string
   ): Observable<{ success: string }> {
     const body = { api_id };

--- a/frontend/src/app/shared/display-cards/card/card.component.html
+++ b/frontend/src/app/shared/display-cards/card/card.component.html
@@ -1,4 +1,5 @@
 <div>
+  <p>RFID: {{ card.rfid }}</p>
   <p>
     API ID:
     <span *ngIf="card.api_id; else pairButton">

--- a/frontend/src/app/shared/display-cards/card/card.component.html
+++ b/frontend/src/app/shared/display-cards/card/card.component.html
@@ -1,0 +1,12 @@
+<div>
+  <p>
+    API ID:
+    <span *ngIf="card.api_id; else pairButton">
+      {{ card.api_id }}
+    </span>
+    <ng-template #pairButton>
+      <button>Pair</button>
+    </ng-template>
+  </p>
+  <p>Mat ID: {{ card.mat_id }}</p>
+</div>

--- a/frontend/src/app/shared/display-cards/card/card.component.html
+++ b/frontend/src/app/shared/display-cards/card/card.component.html
@@ -6,7 +6,7 @@
       {{ card.api_id }}
     </span>
     <ng-template #pairButton>
-      <button>Pair</button>
+      <button [routerLink]="['/admin', 'pair', card.rfid]">Pair</button>
     </ng-template>
   </p>
   <p>Mat ID: {{ card.mat_id }}</p>

--- a/frontend/src/app/shared/display-cards/card/card.component.ts
+++ b/frontend/src/app/shared/display-cards/card/card.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core';
+
+import { Card } from 'src/app/models/card';
+
+@Component({
+  selector: 'card',
+  templateUrl: './card.component.html',
+  styleUrls: ['./card.component.scss'],
+})
+export class CardComponent {
+  @Input() card!: Card;
+
+  constructor() {}
+}

--- a/frontend/src/app/shared/display-cards/display-cards.component.html
+++ b/frontend/src/app/shared/display-cards/display-cards.component.html
@@ -2,10 +2,9 @@
   <h2>Current cards are:</h2>
 
   <div class="horizontal">
-    <span class="padded" *ngFor="let card of cards">
-      <p>API ID: {{ card.api_id }}</p>
-      <p>Mat ID: {{ card.mat_id }}</p>
-    </span>
+    <div class="padded" *ngFor="let c of cards">
+      <card [card]="c" *ngIf="showUnpairedCards || c.api_id !== null" />
+    </div>
   </div>
 
   <div>

--- a/frontend/src/app/shared/display-cards/display-cards.component.ts
+++ b/frontend/src/app/shared/display-cards/display-cards.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 import { Card } from 'src/app/models/card';
 import { GameStateService } from 'src/app/services/game-state.service';
@@ -9,6 +9,8 @@ import { GameStateService } from 'src/app/services/game-state.service';
   styleUrls: ['./display-cards.component.scss'],
 })
 export class DisplayCardsComponent {
+  @Input() showUnpairedCards: boolean = false;
+
   public cards: Card[] = [];
 
   constructor(private readonly gameStateService: GameStateService) {

--- a/frontend/src/app/shared/top-bar/top-bar.component.html
+++ b/frontend/src/app/shared/top-bar/top-bar.component.html
@@ -1,3 +1,3 @@
 <div>
-  <h1>Scrymat</h1>
+  <h1><a routerLink="/">Scrymat</a></h1>
 </div>


### PR DESCRIPTION
Adds functionality to frontend and backend for admins to pick a card from Scryfall to associate with a given RFID.

Usage instructions:
1. Open Donald's `mat_emulator` tool with `pipenv run py mat_emulator.py` in the `tools/` folder.
2. In the emulator, create a mat and send a couple RFIDs to the backend.
3. On the webpage, go to the [admin page](http://localhost:4200/admin).
4. Choose a card without a API ID attached and click the "Pair" button.
5. That should send you to the card search page, where you can search for a magic card and click "Pair" on whichever one you want.
6. Once you click "Pair" on one, you should be redirected back to the admin page, and see an API ID listed under the card you clicked earlier now.