### PR TITLE
Add new fields to Card object

### DIFF
--- a/backend/card.py
+++ b/backend/card.py
@@ -1,14 +1,56 @@
 from typing import Any
+from enum import Enum
+
+
+class MatZone(Enum):
+    """Convert character value into this enum with `MatZone(char)`. Raises ValueError if invalid option."""
+
+    BATTLEFIELD = "B"
+    COMMAND = "C"
+    LIBRARY = "L"
+    GRAVEYARD = "G"
+    EXILE = "E"
 
 
 class Card:
-    """A cards API ID along with the mat it was played to. CONSIDER THIS IMMUTABLE; only CardRepository should directly change its values."""
+    """A cards API ID along with the mat it was played to. CONSIDER THIS IMMUTABLE; only CardRepository should directly change its values.
 
-    def __init__(self, rfid: str, mat_id: str, api_id: str | None = None):
+    Instance Variables
+    ------------------
+    rfid: str
+    mat_id: str
+    api_id: str | None
+    is_face_up: boolean - Default is False
+    front_image: str | None
+    back_image: str | None
+    zone: MatZone | None - None implies that the card is known (possibly has been paired), but not yet present on the mat
+    """
+
+    def __init__(
+        self,
+        rfid: str,
+        mat_id: str,
+        zone: MatZone | None = None,
+        *,
+        api_id: str | None = None,
+    ):
         self.rfid: str = rfid
         self.mat_id: str = mat_id
+        self.zone = None
         self.api_id: str | None = api_id
         """None if the frontend hasn't provided an API ID yet"""
 
+        self.is_face_up = False
+        self.front_image = None
+        self.back_image = None
+
     def toJSON(self) -> dict[str, Any]:
-        return {"rfid": self.rfid, "mat_id": self.mat_id, "api_id": self.api_id}
+        return {
+            "rfid": self.rfid,
+            "mat_id": self.mat_id,
+            "api_id": self.api_id,
+            "is_face_up": self.is_face_up,
+            "front_image": self.front_image,
+            "back_image": self.back_image,
+            "zone": self.zone.value if self.zone else None,
+        }

--- a/backend/card_import_service.py
+++ b/backend/card_import_service.py
@@ -1,0 +1,38 @@
+from typing import Any
+
+from card import Card, MatZone
+from repository import CardRepository
+
+
+class CardImportService:
+    def __init__(self):
+        self.card_repository = CardRepository()
+
+    def import_cards(self, cards_from_json: list[dict[str, Any]]):
+        """Add cards from cards_from_json to repository, overwriting existing ones in the case of conflict.
+        Raises KeyError if cards have invalid format (no cards will be added in this case). cards_from_json should be the direct output of json.decode; a list of dictionaries with at least 'rfid', 'mat_id', and 'api_id' (can be null/None) fields.
+        """
+        new_cards: dict[str, Card] = dict()
+        for card in cards_from_json:
+            # Raises KeyError if these three fields are not supplied
+            rfid = card["rfid"]
+            mat_id = card["mat_id"]
+            api_id = card["api_id"]
+            new_card = Card(rfid, mat_id, api_id=api_id)
+
+            zone = card.get("zone")
+            if zone:
+                new_card.zone = MatZone(zone)
+            new_card.is_face_up = card.get("is_face_up", False)
+            # SECURITY ISSUE: These image URLs are interpolated directly into HTML, maybe check/scrub them before importing?
+            # These default to None if not available
+            new_card.front_image = card.get("front_image")
+            new_card.back_image = card.get("back_image")
+
+            new_cards[rfid] = new_card
+
+        # Note: Will overwrite existing cards with same RFID
+        self.card_repository.bulk_add(new_cards)
+
+
+card_import_service = CardImportService()

--- a/backend/endpoints/import_export.py
+++ b/backend/endpoints/import_export.py
@@ -5,6 +5,7 @@ import json
 from flask import Response, current_app, request
 
 from repository import card_repository
+from card_import_service import card_import_service
 from .frontend_endpoints import get_current_board
 
 
@@ -54,7 +55,7 @@ def import_cards():
     cards_json_data = json.loads(file.stream.read())
     print(f"Importing {len(cards_json_data)} cards...")
     try:
-        card_repository.import_cards(cards_json_data)
+        card_import_service.import_cards(cards_json_data)
     except KeyError as e:
         return {"message": str(e).replace('"', "")}, 400
 

--- a/backend/repository.py
+++ b/backend/repository.py
@@ -28,6 +28,8 @@ class CardRepository:
             self._cards: Dict[int, Card] = {}
             """Dictionary with RFID index and Card values."""
 
+    # ----- READ OPERATIONS -----
+
     def get_card(self, rfid: str) -> Card | None:
         with self._lock:
             return self._cards.get(rfid)
@@ -39,6 +41,8 @@ class CardRepository:
     def get_all_jsonable(self) -> list[dict[str, Any]]:
         with self._lock:
             return [card.toJSON() for card in self._cards.values()]
+
+    # ----- CREATE OPERATIONS -----
 
     def add_card(
         self,
@@ -60,23 +64,43 @@ class CardRepository:
         with self._lock:
             self._cards.update(card_dict)
 
+    # ----- DELETE OPERATIONS -----
+
     def remove_card(self, rfid: str) -> bool:
-        """Returns True if rfid existed and was successfully deleted."""
+        """Raises KeyError if no card with given rfid was found."""
         with self._lock:
-            if rfid in self._cards:
-                self._cards.pop(rfid)
-                return True
-            else:
-                return False
+            self._cards.pop(rfid)
 
     def clear(self) -> None:
         with self._lock:
             self._cards.clear()
 
+    # ----- UPDATE OPERATIONS -----
+
+    def set_zone(self, rfid: str, zone: MatZone | None):
+        """Raises KeyError if no card with given rfid was found."""
+        with self._lock:
+            self._cards[rfid].zone = zone
+
     def set_API_ID(self, rfid: str, api_id: str) -> None:
         """Raises KeyError if no card with given rfid was found."""
         with self._lock:
             self._cards[rfid].api_id = api_id
+
+    def set_images(
+        self, rfid: str, front_image: str | None, back_image: str | None
+    ) -> None:
+        """Raises KeyError if no card with given rfid was found. Only updates image if value is given (None will not delete existing image)."""
+        with self._lock:
+            if front_image:
+                self._cards[rfid].front_image = front_image
+            if back_image:
+                self._cards[rfid].back_image = back_image
+
+    def flip_card(self, rfid: str, to_face_up: bool):
+        """Raises KeyError if no card with given rfid was found."""
+        with self._lock:
+            self._cards[rfid].is_face_up = to_face_up
 
 
 card_repository = CardRepository()

--- a/frontend/src/app/admin-page/card-search/card-search.component.ts
+++ b/frontend/src/app/admin-page/card-search/card-search.component.ts
@@ -47,6 +47,7 @@ export class CardSearchComponent implements OnInit {
       }
     } catch (TypeError) {
       // Card response doesn't follow normal format
+      // TODO: try to get the image another way
     }
     return null;
   }
@@ -59,13 +60,15 @@ export class CardSearchComponent implements OnInit {
       console.error("Error: Can't find card's ID.");
     }
 
-    this.gameStateService.pairAPIId(this.rfid, card['id']).subscribe(
-      (resp) => {
-        console.log('Successfully updated API ID!');
-        this.router.navigate(['/admin']);
-      },
-      (err) =>
-        console.error(`Error updating API ID for card RFID=${this.rfid}`, err)
-    );
+    this.gameStateService
+      .pairAPIId(this.rfid, card['id'], this.getCardImage(card))
+      .subscribe(
+        (resp) => {
+          console.log('Successfully updated API ID!');
+          this.router.navigate(['/admin']);
+        },
+        (err) =>
+          console.error(`Error updating API ID for card RFID=${this.rfid}`, err)
+      );
   }
 }

--- a/frontend/src/app/models/card.ts
+++ b/frontend/src/app/models/card.ts
@@ -1,5 +1,17 @@
+export enum MatZone {
+  BATTLEFIELD = 'B',
+  COMMAND = 'C',
+  LIBRARY = 'L',
+  GRAVEYARD = 'G',
+  EXILE = 'E',
+}
+
 export interface Card {
   rfid: string;
   mat_id: string;
   api_id: string | null;
+  is_face_up: boolean;
+  front_image: string | null;
+  back_image: string | null;
+  zone: MatZone | null;
 }

--- a/frontend/src/app/services/game-state.service.ts
+++ b/frontend/src/app/services/game-state.service.ts
@@ -20,9 +20,11 @@ export class GameStateService {
 
   public pairAPIId(
     rfid: string,
-    api_id: string
+    api_id: string,
+    front_image: string | null = null,
+    back_image: string | null = null
   ): Observable<{ success: string }> {
-    const body = { api_id };
+    const body = { api_id, front_image, back_image };
     return this.http.patch<{ success: string }>(
       BACKEND_URL + `/card/${rfid}`,
       body

--- a/frontend/src/app/shared/display-cards/card/card.component.html
+++ b/frontend/src/app/shared/display-cards/card/card.component.html
@@ -10,4 +10,15 @@
     </ng-template>
   </p>
   <p>Mat ID: {{ card.mat_id }}</p>
+
+  <p>Zone: {{ card.zone }} <span *ngIf="card.zone === null">null</span></p>
+  <p>Face up? {{ card.is_face_up }}</p>
+  <p>
+    Front image: {{ card.front_image }}
+    <span *ngIf="card.front_image === null">null</span>
+  </p>
+  <p>
+    Back image: {{ card.back_image }}
+    <span *ngIf="card.back_image === null">null</span>
+  </p>
 </div>

--- a/frontend/src/app/shared/display-cards/card/card.component.html
+++ b/frontend/src/app/shared/display-cards/card/card.component.html
@@ -21,4 +21,6 @@
     Back image: {{ card.back_image }}
     <span *ngIf="card.back_image === null">null</span>
   </p>
+
+  <img *ngIf="card.front_image" [src]="card.front_image" />
 </div>

--- a/sample_data/cards-with-images.json
+++ b/sample_data/cards-with-images.json
@@ -1,0 +1,38 @@
+[
+  {
+    "rfid": "395fcb4bf89a60e4",
+    "mat_id": "86bacc7f4ce3c86f",
+    "api_id": "61fc0fba-c285-4fad-85a6-79fd7f3f9c35",
+    "is_face_up": false,
+    "front_image": "https://cards.scryfall.io/small/front/6/1/61fc0fba-c285-4fad-85a6-79fd7f3f9c35.jpg?1690006068",
+    "back_image": null,
+    "zone": null
+  },
+  {
+    "rfid": "5a77ad3958658aed",
+    "mat_id": "86bacc7f4ce3c86f",
+    "api_id": "20e94e17-2e4c-41cd-8cc5-39ab41037287",
+    "is_face_up": false,
+    "front_image": null,
+    "back_image": null,
+    "zone": null
+  },
+  {
+    "rfid": "032f89c8ef82fa71",
+    "mat_id": "88f19eb8297306e9",
+    "api_id": "362ec364-39c1-4a4b-8dfa-268fad2effdd",
+    "is_face_up": false,
+    "front_image": "https://cards.scryfall.io/small/front/3/6/362ec364-39c1-4a4b-8dfa-268fad2effdd.jpg?1576383833",
+    "back_image": null,
+    "zone": null
+  },
+  {
+    "rfid": "75ebd78352a17093",
+    "mat_id": "88f19eb8297306e9",
+    "api_id": null,
+    "is_face_up": false,
+    "front_image": null,
+    "back_image": null,
+    "zone": null
+  }
+]


### PR DESCRIPTION
## This PR

This adds 4 new fields to backend's Card object:

- `is_face_up` - A boolean. Whether the card is face up on the mat or not.
- `front_image` - URL of the image of the front of the card (or null if not set).
- `back_image` - URL of the image of the back of the card (or null if not set).
- `zone` - Card location on the mat. Possible options are Battlefield, Library, Graveyard, Exile, or Command.
  - This can also be None/null -- the idea behind this is that if the admin scans all their cards in, then takes their cards off the mat, they will still be saved in the backend, but not displayed. By setting zone to null, we can filter out cards not on the board and prevent them from being displayed.

Since it was a one line addition, I also display the front image on the website if it is available.

![image](https://github.com/user-attachments/assets/698525d4-f762-4604-8f91-26aa4f643817)

I also added `sample_data/cards-with-images.json` to help with testing. Just import the file using the import tool on the admin page.

## Next Steps

- Currently nothing is implemented using `back_image`. I couldn't find where to get this image from Scryfall. We could also potentially save it and have the URL point to the frontend or backend file we saved it to (probably better).
- If `front_image` is provided, it is always displayed. In the future, we want to make sure it is only displayed if `is_face_up` is true, otherwise we should be displaying `back_image` (once we get it working).
- `front_image` is only set if it is a normal card and Scryfall puts the URIs in the normal place. Frontend needs to do some extra logic to find the URI for double sided cards (and then set `back_image` too in this case).
- Frontend currently only gets the "medium" image size. We probably want to start using "large"
- Possibly update `mat_emulator.py`, but again I think it'd be best to just work on the USB listening server and create a new tool there instead (although a lot of the code could probably be copied to there now that I think about it).

I'll write some of these up as issues soon.