### PR TITLE
Mat zones separated in frontend

### DIFF
--- a/frontend/src/app/admin-page/admin-page.component.html
+++ b/frontend/src/app/admin-page/admin-page.component.html
@@ -1,8 +1,12 @@
 <div>
   <h2>This is the admin page</h2>
 
-  <div *ngFor="let matId of mats">
-    <mat-display [matId]="matId" [admin]="true" />
+  <div *ngFor="let matId of mats; index as i">
+    <mat-display
+      [matId]="matId"
+      [admin]="true"
+      playerName="Player {{ i + 1 }}"
+    />
   </div>
 
   <import-export-controls />

--- a/frontend/src/app/admin-page/admin-page.component.html
+++ b/frontend/src/app/admin-page/admin-page.component.html
@@ -2,11 +2,10 @@
   <h2>This is the admin page</h2>
 
   <div *ngFor="let matId of mats">
-    <card-list
+    <mat-display
       [matId]="matId"
       [showUnpairedCards]="true"
       [allowEdit]="true"
-      [debug]="true"
     />
   </div>
 

--- a/frontend/src/app/admin-page/admin-page.component.html
+++ b/frontend/src/app/admin-page/admin-page.component.html
@@ -2,11 +2,7 @@
   <h2>This is the admin page</h2>
 
   <div *ngFor="let matId of mats">
-    <mat-display
-      [matId]="matId"
-      [showUnpairedCards]="true"
-      [allowEdit]="true"
-    />
+    <mat-display [matId]="matId" [admin]="true" />
   </div>
 
   <import-export-controls />

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { EditCardComponent } from './admin-page/edit-card/edit-card.component';
 import { CardResultComponent } from './admin-page/card-search/card-result/card-result.component';
 import { CardListComponent } from './shared/card-list/card-list.component';
 import { CardPileComponent } from './shared/card-pile/card-pile.component';
+import { MatDisplayComponent } from './shared/mat-display/mat-display.component';
 
 @NgModule({
   declarations: [
@@ -37,6 +38,7 @@ import { CardPileComponent } from './shared/card-pile/card-pile.component';
     CardResultComponent,
     CardListComponent,
     CardPileComponent,
+    MatDisplayComponent,
   ],
   imports: [BrowserModule, AppRoutingModule, CommonModule, HttpClientModule],
   providers: [],

--- a/frontend/src/app/main-page/main-page.component.html
+++ b/frontend/src/app/main-page/main-page.component.html
@@ -1,6 +1,6 @@
 <div>
   <h2>Main Page</h2>
   <div *ngFor="let matId of mats">
-    <card-list [matId]="matId" />
+    <mat-display [matId]="matId" />
   </div>
 </div>

--- a/frontend/src/app/main-page/main-page.component.html
+++ b/frontend/src/app/main-page/main-page.component.html
@@ -1,6 +1,6 @@
 <div>
   <h2>Main Page</h2>
-  <div *ngFor="let matId of mats">
-    <mat-display [matId]="matId" />
+  <div *ngFor="let matId of mats; index as i">
+    <mat-display [matId]="matId" playerName="Player {{ i + 1 }}" />
   </div>
 </div>

--- a/frontend/src/app/services/game-state.service.ts
+++ b/frontend/src/app/services/game-state.service.ts
@@ -15,7 +15,7 @@ export class GameStateService {
   public getMats(): Observable<string[]> {
     return this.http
       .get<{ mat_ids: string[] }>(BACKEND_URL + 'mats')
-      .pipe(map((msg) => msg.mat_ids));
+      .pipe(map((msg) => msg.mat_ids.sort()));
   }
 
   public getAllCards(): Observable<Card[]> {

--- a/frontend/src/app/services/mat-listener.service.ts
+++ b/frontend/src/app/services/mat-listener.service.ts
@@ -39,13 +39,13 @@ export class MatListenerService {
     });
 
     this.socket.on('matListUpdate', (matList: string[]) => {
-      this.mats.next(matList);
+      this.mats.next(matList.sort());
     });
 
     // Do normal HTTP requests to get initial values
     this.gameStateService
       .getMats()
-      .subscribe((matList) => this.mats.next(matList));
+      .subscribe((matList) => this.mats.next(matList.sort()));
     this.gameStateService
       .getAllCards()
       .subscribe((cards) => this.cards.next(cards));

--- a/frontend/src/app/shared/card-list/card-list.component.html
+++ b/frontend/src/app/shared/card-list/card-list.component.html
@@ -7,6 +7,8 @@
         {{ c.api_id ? "Re-" : "" }}Pair
       </button>
 
+      <button (click)="flip(c)">Flip</button>
+
       <button [routerLink]="['/admin', 'edit', c.rfid]">Edit data</button>
     </div>
   </div>

--- a/frontend/src/app/shared/card-list/card-list.component.html
+++ b/frontend/src/app/shared/card-list/card-list.component.html
@@ -1,12 +1,12 @@
 <div class="horizontal">
   <div class="padded" *ngFor="let c of cards">
-    <card
-      [card]="c"
-      *ngIf="showUnpairedCards || c.api_id !== null"
-      [debug]="debug"
-    />
+    <card [card]="c" [debug]="debug" />
 
     <div *ngIf="allowEdit">
+      <button [routerLink]="['/admin', 'pair', c.rfid]">
+        {{ c.api_id ? "Re-" : "" }}Pair
+      </button>
+
       <button [routerLink]="['/admin', 'edit', c.rfid]">Edit data</button>
     </div>
   </div>

--- a/frontend/src/app/shared/card-list/card-list.component.html
+++ b/frontend/src/app/shared/card-list/card-list.component.html
@@ -1,17 +1,13 @@
-<div>
-  <h2>Mat #{{ matId }}</h2>
+<div class="horizontal">
+  <div class="padded" *ngFor="let c of cards">
+    <card
+      [card]="c"
+      *ngIf="showUnpairedCards || c.api_id !== null"
+      [debug]="debug"
+    />
 
-  <div class="horizontal">
-    <div class="padded" *ngFor="let c of cards">
-      <card
-        [card]="c"
-        *ngIf="showUnpairedCards || c.api_id !== null"
-        [debug]="debug"
-      />
-
-      <div *ngIf="allowEdit">
-        <button [routerLink]="['/admin', 'edit', c.rfid]">Edit data</button>
-      </div>
+    <div *ngIf="allowEdit">
+      <button [routerLink]="['/admin', 'edit', c.rfid]">Edit data</button>
     </div>
   </div>
 </div>

--- a/frontend/src/app/shared/card-list/card-list.component.ts
+++ b/frontend/src/app/shared/card-list/card-list.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 
 import { Card } from 'src/app/models/card';
+import { GameStateService } from 'src/app/services/game-state.service';
 
 @Component({
   selector: 'card-list',
@@ -11,4 +12,12 @@ export class CardListComponent {
   @Input() cards: Card[] = [];
   @Input() allowEdit: boolean = false;
   @Input() debug: boolean = false;
+
+  constructor(private readonly gameStateService: GameStateService) {}
+
+  public flip(card: Card) {
+    if (this.allowEdit) {
+      this.gameStateService.flipCard(card.rfid, !card.is_face_up).subscribe();
+    }
+  }
 }

--- a/frontend/src/app/shared/card-list/card-list.component.ts
+++ b/frontend/src/app/shared/card-list/card-list.component.ts
@@ -1,62 +1,15 @@
-import {
-  Component,
-  Input,
-  OnChanges,
-  OnInit,
-  SimpleChanges,
-} from '@angular/core';
-import { Subscription } from 'rxjs';
+import { Component, Input } from '@angular/core';
 
 import { Card } from 'src/app/models/card';
-import { GameStateService } from 'src/app/services/game-state.service';
-import { MatListenerService } from 'src/app/services/mat-listener.service';
 
 @Component({
   selector: 'card-list',
   templateUrl: './card-list.component.html',
   styleUrls: ['./card-list.component.scss'],
 })
-export class CardListComponent implements OnInit, OnChanges {
-  @Input() matId: string | null = null;
+export class CardListComponent {
+  @Input() cards: Card[] = [];
   @Input() showUnpairedCards: boolean = false;
   @Input() allowEdit: boolean = false;
   @Input() debug: boolean = false;
-
-  public cards: Card[] = [];
-
-  private cardsSubscription: Subscription | null = null;
-
-  constructor(
-    private readonly gameStateService: GameStateService,
-    private readonly matListener: MatListenerService
-  ) {}
-
-  public ngOnInit(): void {
-    this.resetCardsSubscription(this.matId);
-  }
-
-  public ngOnChanges(changes: SimpleChanges): void {
-    if (changes['matId']) {
-      this.resetCardsSubscription(changes['matId'].currentValue);
-    }
-  }
-
-  public refreshCardList() {
-    this.gameStateService
-      .getAllCards()
-      .subscribe((cardList) => (this.cards = cardList));
-  }
-
-  private resetCardsSubscription(matId: string | null) {
-    this.cardsSubscription?.unsubscribe();
-    if (matId) {
-      this.cardsSubscription = this.matListener
-        .getCardsForMat$(matId)
-        .subscribe((cardList) => (this.cards = cardList));
-    } else {
-      this.cardsSubscription = this.matListener
-        .getCards$()
-        .subscribe((cardList) => (this.cards = cardList));
-    }
-  }
 }

--- a/frontend/src/app/shared/card-list/card-list.component.ts
+++ b/frontend/src/app/shared/card-list/card-list.component.ts
@@ -9,7 +9,6 @@ import { Card } from 'src/app/models/card';
 })
 export class CardListComponent {
   @Input() cards: Card[] = [];
-  @Input() showUnpairedCards: boolean = false;
   @Input() allowEdit: boolean = false;
   @Input() debug: boolean = false;
 }

--- a/frontend/src/app/shared/card-pile/card-pile.component.html
+++ b/frontend/src/app/shared/card-pile/card-pile.component.html
@@ -1,4 +1,7 @@
 <div>
-  <p>This is a card pile</p>
-  <p>This component is for the Graveyard, Library, Exile, etc.</p>
+  <card *ngIf="cards.length" [card]="cards[0]" />
+  <div><button (click)="debugPrint()">Print cards in console</button></div>
+  <p>
+    <i>({{ cards.length }} cards)</i>
+  </p>
 </div>

--- a/frontend/src/app/shared/card-pile/card-pile.component.ts
+++ b/frontend/src/app/shared/card-pile/card-pile.component.ts
@@ -1,10 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
+import { Card } from 'src/app/models/card';
 
 @Component({
   selector: 'card-pile',
   templateUrl: './card-pile.component.html',
-  styleUrls: ['./card-pile.component.scss']
+  styleUrls: ['./card-pile.component.scss'],
 })
 export class CardPileComponent {
+  @Input() cards: Card[] = [];
 
+  public debugPrint() {
+    console.log('Cards in pile are:', this.cards);
+  }
 }

--- a/frontend/src/app/shared/mat-display/mat-display.component.html
+++ b/frontend/src/app/shared/mat-display/mat-display.component.html
@@ -1,0 +1,36 @@
+<div>
+  <h2>Mat #{{ matId }}</h2>
+
+  <card-list
+    [cards]="battlefieldCards"
+    [showUnpairedCards]="showUnpairedCards"
+    [allowEdit]="allowEdit"
+  />
+
+  <div class="horizontal">
+    <div>
+      <h3>Library</h3>
+      <card-pile [cards]="libraryCards" />
+    </div>
+
+    <div>
+      <h3>Graveyard</h3>
+      <card-pile [cards]="graveyardCards" />
+    </div>
+
+    <div>
+      <h3>Exile</h3>
+      <card-pile [cards]="exileCards" />
+    </div>
+
+    <div>
+      <h3>Command</h3>
+      <card-pile [cards]="commandCards" />
+    </div>
+
+    <div>
+      <h3>Not Present</h3>
+      <card-pile [cards]="notPresentCards" />
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/shared/mat-display/mat-display.component.html
+++ b/frontend/src/app/shared/mat-display/mat-display.component.html
@@ -32,7 +32,7 @@
       <card-pile [cards]="commandCards" />
     </div>
 
-    <div class="padded">
+    <div *ngIf="admin" class="padded">
       <h3>Not Present</h3>
       <card-pile [cards]="notPresentCards" />
     </div>

--- a/frontend/src/app/shared/mat-display/mat-display.component.html
+++ b/frontend/src/app/shared/mat-display/mat-display.component.html
@@ -12,27 +12,27 @@
   </div>
 
   <div class="horizontal">
-    <div>
+    <div class="padded">
       <h3>Library</h3>
       <card-pile [cards]="libraryCards" />
     </div>
 
-    <div>
+    <div class="padded">
       <h3>Graveyard</h3>
       <card-pile [cards]="graveyardCards" />
     </div>
 
-    <div>
+    <div class="padded">
       <h3>Exile</h3>
       <card-pile [cards]="exileCards" />
     </div>
 
-    <div>
+    <div class="padded">
       <h3>Command</h3>
       <card-pile [cards]="commandCards" />
     </div>
 
-    <div>
+    <div class="padded">
       <h3>Not Present</h3>
       <card-pile [cards]="notPresentCards" />
     </div>

--- a/frontend/src/app/shared/mat-display/mat-display.component.html
+++ b/frontend/src/app/shared/mat-display/mat-display.component.html
@@ -1,11 +1,15 @@
 <div>
   <h2>Mat #{{ matId }}</h2>
 
-  <card-list
-    [cards]="battlefieldCards"
-    [showUnpairedCards]="showUnpairedCards"
-    [allowEdit]="allowEdit"
-  />
+  <div *ngIf="admin && unpairedCards.length > 0">
+    <h3>Unpaired Cards</h3>
+    <card-list [cards]="unpairedCards" [allowEdit]="admin" />
+  </div>
+
+  <div>
+    <h3>Battlefield</h3>
+    <card-list [cards]="battlefieldCards" [allowEdit]="admin" />
+  </div>
 
   <div class="horizontal">
     <div>

--- a/frontend/src/app/shared/mat-display/mat-display.component.html
+++ b/frontend/src/app/shared/mat-display/mat-display.component.html
@@ -1,5 +1,6 @@
 <div>
-  <h2>Mat #{{ matId }}</h2>
+  <h2 *ngIf="playerName !== null">{{ playerName }}</h2>
+  <h2 *ngIf="playerName === null && matId">Mat #{{ matId }}</h2>
 
   <div *ngIf="admin && unpairedCards.length > 0">
     <h3>Unpaired Cards</h3>

--- a/frontend/src/app/shared/mat-display/mat-display.component.scss
+++ b/frontend/src/app/shared/mat-display/mat-display.component.scss
@@ -1,0 +1,7 @@
+.horizontal {
+  display: flex;
+}
+
+.padded {
+  padding: 5px;
+}

--- a/frontend/src/app/shared/mat-display/mat-display.component.ts
+++ b/frontend/src/app/shared/mat-display/mat-display.component.ts
@@ -20,6 +20,8 @@ export class MatDisplayComponent implements OnInit, OnChanges {
   @Input() matId: string | null = null;
   /** This enables card edits, (re)pairing, and showing unpaired cards */
   @Input() admin: boolean = false;
+  /** Optional name for the header. Uses matId if null. */
+  @Input() playerName: string | null = null;
 
   public pairedCards: Card[] = [];
   public unpairedCards: Card[] = [];

--- a/frontend/src/app/shared/mat-display/mat-display.component.ts
+++ b/frontend/src/app/shared/mat-display/mat-display.component.ts
@@ -1,0 +1,80 @@
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+} from '@angular/core';
+import { Subscription } from 'rxjs';
+
+import { Card, MatZone } from 'src/app/models/card';
+import { GameStateService } from 'src/app/services/game-state.service';
+import { MatListenerService } from 'src/app/services/mat-listener.service';
+
+@Component({
+  selector: 'mat-display',
+  templateUrl: './mat-display.component.html',
+  styleUrls: ['./mat-display.component.scss'],
+})
+export class MatDisplayComponent implements OnInit, OnChanges {
+  @Input() matId: string | null = null;
+  @Input() showUnpairedCards: boolean = false;
+  @Input() allowEdit: boolean = false;
+
+  public cards: Card[] = [];
+
+  public get battlefieldCards(): Card[] {
+    return this.cards.filter((c) => c.zone === MatZone.BATTLEFIELD);
+  }
+  public get commandCards(): Card[] {
+    return this.cards.filter((c) => c.zone === MatZone.COMMAND);
+  }
+  public get exileCards(): Card[] {
+    return this.cards.filter((c) => c.zone === MatZone.EXILE);
+  }
+  public get graveyardCards(): Card[] {
+    return this.cards.filter((c) => c.zone === MatZone.GRAVEYARD);
+  }
+  public get libraryCards(): Card[] {
+    return this.cards.filter((c) => c.zone === MatZone.LIBRARY);
+  }
+  public get notPresentCards(): Card[] {
+    return this.cards.filter((c) => c.zone === MatZone.NOT_PRESENT);
+  }
+
+  private cardsSubscription: Subscription | null = null;
+
+  constructor(
+    private readonly gameStateService: GameStateService,
+    private readonly matListener: MatListenerService
+  ) {}
+
+  public ngOnInit(): void {
+    this.resetCardsSubscription(this.matId);
+  }
+
+  public ngOnChanges(changes: SimpleChanges): void {
+    if (changes['matId']) {
+      this.resetCardsSubscription(changes['matId'].currentValue);
+    }
+  }
+
+  public refreshCardList() {
+    this.gameStateService
+      .getAllCards()
+      .subscribe((cardList) => (this.cards = cardList));
+  }
+
+  private resetCardsSubscription(matId: string | null) {
+    this.cardsSubscription?.unsubscribe();
+    if (matId) {
+      this.cardsSubscription = this.matListener
+        .getCardsForMat$(matId)
+        .subscribe((cardList) => (this.cards = cardList));
+    } else {
+      this.cardsSubscription = this.matListener
+        .getCards$()
+        .subscribe((cardList) => (this.cards = cardList));
+    }
+  }
+}


### PR DESCRIPTION
Separates cards by what zone they are in.

Note that Battlefield is the only zone where cards get spread out horizontally, the rest just displays the first card in their list. I added a button to print their lists to console for debugging these.

In the Admin page, unpaired cards appear first in a spread out horizontal section (like the Battlefield) no matter what zone they belong to (they are not displayed in those zones while unpaired).